### PR TITLE
feat: add optional temperature configuration for LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ All options are optional _except_ for `-p, --prompt`, which is required.
 - `-f, --files <file>` (optional): One or more files to send as input
 - `--base-url <url>` (optional): API endpoint (default: http://localhost:11434/v1)
 - `--api-key <key>` (optional): API key for authentication, if needed
+- `--temperature <float>` (optional): LLM temperature between 0.0 (deterministic) and 2.0 (creative)
 - `-v, --verbose` (optional): Enable verbose logging (use -v for basic debug, -vv for detailed request/response info)
 - `--version` (optional): Show version information
 
@@ -99,6 +100,7 @@ model = "llama3"
 base_url = "http://localhost:11434/v1"
 api_key = "your-api-key-here"
 default_prompt = "You are a helpful assistant."
+temperature = 0.7  # Optional: omit to use LLM's default temperature
 ```
 
 Command-line arguments will override config file values.

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ struct AppConfig {
     base_url: String,
     api_key: Option<String>,
     default_prompt: Option<String>,
-    temperature: f32,
+    temperature: Option<f32>,
     timeout_secs: u64,
 }
 
@@ -46,7 +46,7 @@ impl AppConfig {
             base_url: "http://localhost:11434/v1".to_string(),
             api_key: None,
             default_prompt: None,
-            temperature: 0.7,
+            temperature: Some(0.7),
             timeout_secs: 300, // 300 seconds default timeout
         }
     }
@@ -107,7 +107,8 @@ struct ChatCompletionRequest {
     model: String,
     messages: Vec<ChatMessage>,
     stream: bool,
-    temperature: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -179,7 +180,7 @@ pub async fn main() -> Result<()> {
     // Build the request
     info!("Building request with configuration");
     debug!(
-        "Using model: {}, base_url: {}, temperature: {}, first-chunk timeout: {}s",
+        "Using model: {}, base_url: {}, temperature: {:?}, first-chunk timeout: {}s",
         config.model, config.base_url, config.temperature, config.timeout_secs
     );
 
@@ -246,11 +247,12 @@ async fn get_final_config(args: &Args) -> Result<AppConfig> {
 
     if let Some(temperature) = args.temperature {
         debug!("Overriding temperature with command line argument: {temperature}");
-        config.temperature = validate_temperature(temperature)?;
-    } else {
+        config.temperature = Some(validate_temperature(temperature)?);
+    } else if let Some(temperature) = config.temperature {
         // Validate the config file temperature as well
-        config.temperature = validate_temperature(config.temperature)?;
+        config.temperature = Some(validate_temperature(temperature)?);
     }
+    // If temperature is None in both config and args, leave it as None to use LLM default
 
     if let Some(timeout) = args.timeout {
         debug!("Overriding timeout with command line argument: {timeout}s");
@@ -258,7 +260,7 @@ async fn get_final_config(args: &Args) -> Result<AppConfig> {
     }
 
     info!(
-        "Final configuration: model={}, base_url={}, temperature={}, timeout={}s",
+        "Final configuration: model={}, base_url={}, temperature={:?}, timeout={}s",
         config.model, config.base_url, config.temperature, config.timeout_secs
     );
     if config.api_key.is_some() {
@@ -406,7 +408,7 @@ async fn stream_response(
 
     // Enhanced logging for debugging - log full request details
     trace!("=== SERVICE CALL DETAILS ===");
-    trace!("URL: {}", url);
+    trace!("URL: {url}");
     trace!(
         "Request Body: {}",
         serde_json::to_string_pretty(&request)
@@ -419,7 +421,7 @@ async fn stream_response(
         headers_log.push_str("Authorization: Bearer ***, ");
     }
     headers_log.push_str("Content-Type: application/json");
-    trace!("{}", headers_log);
+    trace!("{headers_log}");
     trace!("=== END SERVICE CALL DETAILS ===");
 
     info!("Sending streaming request to API");
@@ -471,7 +473,7 @@ async fn stream_response(
         let text = std::str::from_utf8(&chunk)
             .with_context(|| String::from("Failed to decode response as UTF-8"))?;
         debug!("Received chunk {}: {} bytes", chunk_count, chunk.len());
-        trace!("Chunk {} content: {:?}", chunk_count, text);
+        trace!("Chunk {chunk_count} content: {text:?}");
         incomplete.push_str(text);
     } else {
         return Err(anyhow::anyhow!("Stream ended before any data was received"));
@@ -485,7 +487,7 @@ async fn stream_response(
             .with_context(|| String::from("Failed to decode response as UTF-8"))?;
 
         debug!("Received chunk {}: {} bytes", chunk_count, chunk.len());
-        trace!("Chunk {} content: {:?}", chunk_count, text);
+        trace!("Chunk {chunk_count} content: {text:?}");
         incomplete.push_str(text);
 
         // Process complete lines only

--- a/src/unit_tests.rs
+++ b/src/unit_tests.rs
@@ -141,6 +141,20 @@ fn test_temperature_validation() {
 #[test]
 fn test_config_defaults() {
     let config = AppConfig::default();
-    assert_eq!(config.temperature, 0.7);
+    assert_eq!(config.temperature, Some(0.7));
     assert_eq!(config.timeout_secs, 300);
+}
+
+#[test]
+fn test_config_without_temperature() {
+    // Test that we can create a config without temperature (using LLM default)
+    let config = AppConfig {
+        model: "llama3".to_string(),
+        base_url: "http://localhost:11434/v1".to_string(),
+        api_key: None,
+        default_prompt: None,
+        temperature: None, // This should be allowed now
+        timeout_secs: 300,
+    };
+    assert_eq!(config.temperature, None);
 }


### PR DESCRIPTION
- Updated the AppConfig struct to allow temperature to be an optional field.
- Modified the default configuration to set temperature as Some(0.7).
- Enhanced command-line argument handling to support overriding temperature.
- Updated README to document the new --temperature option.
- Added unit tests to verify behavior with and without temperature settings.