### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -46,6 +46,8 @@ jobs:
 
   build-pre-release:
     name: Build Pre-Release
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/development' && github.event_name == 'push'
     timeout-minutes: 20


### PR DESCRIPTION
Potential fix for [https://github.com/brianbirrell/ai-cli/security/code-scanning/3](https://github.com/brianbirrell/ai-cli/security/code-scanning/3)

To fix the problem, we must explicitly set job-level permissions for the `build-pre-release` job in `.github/workflows/development.yml`. The safest and most minimal set of permissions is likely `contents: read`, which permits read-only access to repository contents (i.e., reading source code for building and testing, but not writing or modifying contents, releases, or other resources). This should be added just below the job name in the `build-pre-release` job definition, matching the pattern already present in `create-development-release`.  

**Steps:**
- Edit `.github/workflows/development.yml`.
- Add the following block just beneath line 48 (`name: Build Pre-Release`) as line 49:
  ```yaml
  permissions:
    contents: read
  ```
- Change all subsequent line numbers up by two.
- No imports or further method/variable definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
