### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust_validation.yml
+++ b/.github/workflows/rust_validation.yml
@@ -1,4 +1,6 @@
 name: Rust CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brianbirrell/ai-cli/security/code-scanning/2](https://github.com/brianbirrell/ai-cli/security/code-scanning/2)

To fix the issue, you should explicitly set the `permissions` block in your workflow to ensure GITHUB_TOKEN has only the minimal access required. Since this workflow only needs to read the repository contents (for checking out code), setting `contents: read` either at the workflow root or within each job is sufficient.  
The single best way to fix this is to insert:
```yaml
permissions:
  contents: read
```
directly under the workflow's `name` key and before other root-level keys such as `on`, `env`, and `jobs` (recommended practice is at the workflow root unless jobs require different permission levels).  
No other changes or imports are needed, and this will apply the restriction to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
