### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   test-development:
     name: Test Development
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
     


### PR DESCRIPTION
Potential fix for [https://github.com/brianbirrell/ai-cli/security/code-scanning/1](https://github.com/brianbirrell/ai-cli/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block to the `test-development` job to ensure that only the least privileges needed are granted. Since the job does not require any write access, granting `contents: read` is appropriate and follows the principle of least privilege. This can be accomplished by inserting 
```yaml
permissions:
  contents: read
```
directly under line 15 (`name: Test Development`) and before other job keys like `runs-on`. No imports or additional methods/definitions are required. Only the workflow YAML file is changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
